### PR TITLE
Fix prisma mongodb to postgresql connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.13.0",
-        "@prisma/extension-accelerate": "^2.0.2",
         "clsx": "^2.1.1",
         "next": "15.4.1",
         "react": "19.1.0",
@@ -1085,17 +1084,6 @@
       "integrity": "sha512-MpPyKSzBX7P/ZY9odp9TSegnS/yH3CSbchQE9f0yBg3l2QyN59I6vGXcoYcqKC9VTniS1s18AMmhyr1OWavjHg==",
       "devOptional": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@prisma/extension-accelerate": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@prisma/extension-accelerate/-/extension-accelerate-2.0.2.tgz",
-      "integrity": "sha512-yZK6/k7uOEFpEsKoZezQS1CKDboPtBCQ0NyI70e1Un8tDiRgg80iWGyjsJmRpps2ZIut3MroHP+dyR3wVKh8lA==",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@prisma/client": ">=4.16.1"
-      }
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.13.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../src/generated/prisma"
 }
 
 datasource db {


### PR DESCRIPTION
Remove custom Prisma client output path and unused accelerate extension to resolve MongoDB schema validation error after switching to PostgreSQL.

The previous Prisma setup generated the client to a custom path, which, combined with Next.js caching, caused the application to still use a MongoDB-configured client even after the `schema.prisma` was updated to PostgreSQL. This change ensures the Prisma client is generated to the standard `node_modules` location, allowing the correct PostgreSQL client to be used. The accelerate extension was also removed as it was no longer needed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7bb7d64-b3b5-4b32-a7b8-8d06430c1fc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7bb7d64-b3b5-4b32-a7b8-8d06430c1fc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

